### PR TITLE
Magic Packetが正常に送信されない原因の解決に伴い、request.args.getを request.form.getに変更。Change request.args.get to request.form.get because Magic Packet was not being sent properly.

### DIFF
--- a/wol.py
+++ b/wol.py
@@ -5,7 +5,7 @@ app = Flask(__name__)
 
 @app.route("/wol", methods=['GET', 'POST'])
 def wol():
-    addr = request.args.get('addr', '')
+    addr = request.form.get('addr', '')
     message = ""
 
     if request.method == 'POST':


### PR DESCRIPTION
この変更により wakeonlan ライブラリの mac アドレスのフォーマットエラーが修正され、マジックパケットが正しく送信されるようになったことを確認いたしました。
この変更を行わず、リポジトリの設定通りにサーバーを立てたところ、パケットが正常に送信されていませんでした。
systemctl statusで確かめたところ、以下のようなエラーが出ていたので、それを解決した形になります。

I have confirmed that this change corrects a formatting error in the mac address of the wakeonlan library and that magic packets are now sent correctly.
When I set up the server as configured in the repository without this change, the packets were not being sent correctly.
I checked with `systemctl status` and found the following error, which is now fixed.

```
10月 31 18:42:23 raspberrypi uwsgi[4636]:   File "/var/www/wakeonlan-server/env/lib/python3.11/site-packages/wakeonlan/__init__.py", line 63, in send_magic_packet
10月 31 18:42:23 raspberrypi uwsgi[4636]:     packets = [create_magic_packet(mac) for mac in macs]
10月 31 18:42:23 raspberrypi uwsgi[4636]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
10月 31 18:42:23 raspberrypi uwsgi[4636]:   File "/var/www/wakeonlan-server/env/lib/python3.11/site-packages/wakeonlan/__init__.py", line 63, in <listcomp>
10月 31 18:42:23 raspberrypi uwsgi[4636]:     packets = [create_magic_packet(mac) for mac in macs]
10月 31 18:42:23 raspberrypi uwsgi[4636]:                ^^^^^^^^^^^^^^^^^^^^^^^^
10月 31 18:42:23 raspberrypi uwsgi[4636]:   File "/var/www/wakeonlan-server/env/lib/python3.11/site-packages/wakeonlan/__init__.py", line 36, in create_magic_packet
10月 31 18:42:23 raspberrypi uwsgi[4636]:     raise ValueError("Incorrect MAC address format")
10月 31 18:42:23 raspberrypi uwsgi[4636]: ValueError: Incorrect MAC address format
10月 31 18:42:23 raspberrypi uwsgi[4636]: [pid: 4636|app: 0|req: 1/2] 100.122.56.117 () {52 vars in 960 bytes} [Thu Oct 31 18:42:23 2024] POST /wol => generated 265 bytes in 43 msecs (HTTP/1.1 500) 2 headers in 99 bytes (2 switches on co>
```
